### PR TITLE
Fix risk manager check

### DIFF
--- a/backtest/backtest_runner.py
+++ b/backtest/backtest_runner.py
@@ -149,7 +149,7 @@ class BacktestRunner:
             # Risk management (stop if circuit breaker triggered)
             if risk_manager and hasattr(risk_manager, "__call__"):
                 # Pass the environment so risk checks can access positions and equity
-                if risk_manager(env, state):
+                if not risk_manager(env, state):
                     logger.warning("Risk manager triggered circuit breaker. Stopping backtest.")
                     break
 


### PR DESCRIPTION
## Summary
- fix boolean logic for risk manager in `BacktestRunner`

## Testing
- `pip install pandas==2.1.0 numpy==1.23 gym==0.26` *(fails: metadata-generation-failed)*

------
https://chatgpt.com/codex/tasks/task_e_688674ea62948321a749d1e8a8662c47