### PR TITLE
Fix risk management call and checkpoint logic

### DIFF
--- a/agents/dqn_agent.py
+++ b/agents/dqn_agent.py
@@ -223,6 +223,8 @@ class DQNAgent:
     def save_checkpoint(self, name="dqn_agent.pth"):
         """Save agent weights and optimizer state."""
         save_path = os.path.join(self.checkpoint_dir, name)
+        # Ensure the checkpoint directory exists before saving
+        os.makedirs(self.checkpoint_dir, exist_ok=True)
         torch.save({
             "q_net": self.q_net.state_dict(),
             "target_net": self.target_net.state_dict(),

--- a/backtest/backtest_runner.py
+++ b/backtest/backtest_runner.py
@@ -148,7 +148,9 @@ class BacktestRunner:
 
             # Risk management (stop if circuit breaker triggered)
             if risk_manager and hasattr(risk_manager, "__call__"):
-                if risk_manager(metrics, state):
+                # Pass the environment so risk checks can access positions and equity
+                # break if the risk manager signals unsafe conditions
+                if not risk_manager(env, state):
                     logger.warning("Risk manager triggered circuit breaker. Stopping backtest.")
                     break
 

--- a/risk/risk_manager.py
+++ b/risk/risk_manager.py
@@ -83,12 +83,13 @@ class RiskManager:
         return price * total_qty * (self.transaction_cost + self.slippage)
 
     def dynamic_position_size(self, confidence, base_size=1, min_size=0.25, max_size=2.0):
-        
+
         conf = np.clip(confidence, -1, 1)
         if conf >= 0:
             size = base_size + (max_size - base_size) * conf
         else:
-            size = base_size + (min_size - base_size) * conf
+            # When confidence is negative, scale position towards the minimum size
+            size = base_size + (min_size - base_size) * (-conf)
         return np.clip(size, min_size, max_size)
 
 


### PR DESCRIPTION
## Summary
- pass env to risk manager and only stop when risk checks fail
- ensure negative confidence reduces position size correctly
- create checkpoint dir before saving DQN model

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68861ae699588321a8658211414d86fd