### PR TITLE
Uncomment broker APIs in requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
 Dev -
-cd C:\myproject\bots\opttrbot                                                                          
->> .\.venv\Scripts\activate    
+cd C:\myproject\bots\opttrbot
+>> .\.venv\Scripts\activate
+
+## Installation
+
+Install required packages including the broker APIs (`smartapi-python`,
+`angel-one-api` and `kiteconnect`):
+
+```bash
+pip install -r requirements.txt
+```
 =============
 For tranning the bot >>>>>>
 Training the Bot Overnight :-

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,9 +25,9 @@ tqdm>=4.65
 APScheduler>=3.10
 
 # ===== BROKER/EXCHANGE APIs (Uncomment as needed) =====
-# smartapi-python>=1.0.2
-# angel-one-api>=1.0.0
-# kiteconnect>=4.1.0
+smartapi-python>=1.0.2
+angel-one-api>=1.0.0
+kiteconnect>=4.1.0
 
 # ===== DEVELOPMENT/DEBUGGING =====
 ipython


### PR DESCRIPTION
## Summary
- add installation instructions in README
- include smartapi-python, angel-one-api, and kiteconnect in requirements

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6889dc12875c832196196c5ff0d82fe1