### PR TITLE
Fix OTP generation with remote time

### DIFF
--- a/data/data_fetch.py
+++ b/data/data_fetch.py
@@ -11,6 +11,7 @@ import pyotp
 import yaml
 from tqdm import tqdm
 from utils.logger import get_logger
+from utils.utils import totp_now
 
 logger = get_logger("DataFetch")
 
@@ -22,13 +23,13 @@ client_id = keys["client_id"]
 pwd = keys["password"]
 totp_key = keys.get("totp_secret") or keys.get("totp")  # support both keys
 
-otp = pyotp.TOTP(totp_key).now()
+otp = totp_now(totp_key)
 api = SmartConnect(api_key=api_key)
 api.generateSession(client_id, pwd, otp)
 
 def relogin():
     """Generate a fresh OTP and refresh the Smart API session."""
-    otp = pyotp.TOTP(totp_key).now()
+    otp = totp_now(totp_key)
     api.generateSession(client_id, pwd, otp)
     logger.info("Session refreshed via relogin().")
 

--- a/utils/angel_one_api.py
+++ b/utils/angel_one_api.py
@@ -7,6 +7,7 @@ from SmartApi import SmartConnect
 import pyotp
 import yaml
 from utils.logger import get_logger
+from utils.utils import totp_now
 
 logger = get_logger("AngelOneAPI")
 
@@ -46,7 +47,7 @@ class AngelOneAPI:
     def _login(self):
         api = SmartConnect(api_key=self.api_key)
         try:
-            otp = pyotp.TOTP(self.totp_secret).now() if self.totp_secret else self.totp
+            otp = totp_now(self.totp_secret) if self.totp_secret else self.totp
             data = api.generateSession(self.client_id, self.password, otp)
             logger.info("AngelOne login successful.")
         except Exception as e:


### PR DESCRIPTION
## Summary
- use remote UTC time when generating OTP to avoid issues with system clock skew
- update data fetching and AngelOne API login to call new helper

## Testing
- `pytest -q`
- `flake8` *(fails: many style issues in repo)*

------
https://chatgpt.com/codex/tasks/task_e_688a5ec28ac883219b6bc511ed7da9f1