### PR TITLE
Fix timeapi url

### DIFF
--- a/utils/utils.py
+++ b/utils/utils.py
@@ -188,7 +188,7 @@ def current_utc_unixtime():
 
     Falls back to local time if the request fails.
     """
-    url = "http://worldtimeapi.org/api/timezone/Etc/UTC"
+    url = "https://worldtimeapi.org/api/timezone/Etc/UTC"
     try:
         resp = requests.get(url, timeout=5)
         if resp.status_code == 200:


### PR DESCRIPTION
## Summary
- use HTTPS for worldtimeapi in `current_utc_unixtime`

## Testing
- `pip install -q pyotp`
- `python - <<'EOF'
from utils.utils import current_utc_unixtime, totp_now
print('Time:', current_utc_unixtime())
print('TOTP:', totp_now('JBSWY3DPEHPK3PXP'))
EOF`

------
https://chatgpt.com/codex/tasks/task_e_688b42ce2e4c8321969c76568207cf6f