### PR TITLE
Validate missing TOTP secret

### DIFF
--- a/data/data_fetch.py
+++ b/data/data_fetch.py
@@ -20,6 +20,11 @@ client_id = os.getenv("ANGEL_CLIENT_ID")
 pwd = os.getenv("ANGEL_PASSWORD")
 totp_key = os.getenv("ANGEL_TOTP_SECRET") or os.getenv("TOTP_SECRET") or os.getenv("TOTP")
 
+if not totp_key:
+    raise ValueError(
+        "TOTP secret not set; please define ANGEL_TOTP_SECRET"
+    )
+
 otp = totp_now(totp_key)
 api = SmartConnect(api_key=api_key)
 resp = api.generateSession(client_id, pwd, otp)


### PR DESCRIPTION
## Summary
- validate the presence of ANGEL_TOTP_SECRET before generating OTP

## Testing
- `python -m py_compile data/data_fetch.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b604c040c83218d010cbaf952ac05